### PR TITLE
Add language string for privacy provider

### DIFF
--- a/lang/en/tiny_codepro.php
+++ b/lang/en/tiny_codepro.php
@@ -23,5 +23,6 @@
  */
 $string['plugin'] = 'codePro';
 $string['pluginname'] = 'Source code Pro';
+$string['privacy:metadata'] = 'This plugin does not store any user related data.';
 $string['cancel'] = 'Cancel';
 $string['save'] = 'Save';


### PR DESCRIPTION
This PR adds the 'privacy:metadata' language string to resolve the unit test error in Issue #5 