### PR TITLE
Revert the changes related to not using Bootstrap tooltips

### DIFF
--- a/templates/modal.mustache
+++ b/templates/modal.mustache
@@ -43,10 +43,10 @@
     {{/body}}
     {{$footer}}
         <div class="tiny_codepro-left">
-            <button class="btn btn-light" data-fs="false" data-toggle="tooltip" title="Fullscreen"><i class="fa fa-arrows-alt"></i></button>
-            <button class="btn btn-light" data-theme="light" data-toggle="tooltip" title="Light/Dark themes"><i class="fa fa-sun-o"></i></button>
-            <button class="btn btn-light" data-wrap="true" data-toggle="tooltip" title="Line wrap"><i class="fa fa-exchange"></i></button>
-            <button class="btn btn-light" data-prettify="true" data-toggle="tooltip" title="Prettify code"><i class="fa fa-magic"></i></button>
+            <button class="btn btn-light" data-fs="false" title="Fullscreen"><i class="fa fa-arrows-alt"></i></button>
+            <button class="btn btn-light" data-theme="light" title="Light/Dark themes"><i class="fa fa-sun-o"></i></button>
+            <button class="btn btn-light" data-wrap="true" title="Line wrap"><i class="fa fa-exchange"></i></button>
+            <button class="btn btn-light" data-prettify="true" title="Prettify code"><i class="fa fa-magic"></i></button>
         </div>
         <button class="btn btn-secondary" data-action="cancel">{{#str}} cancel, tiny_codepro {{/str}}</button>
         <button class="btn btn-primary" data-action="save">{{#str}} save, tiny_codepro {{/str}}</button>


### PR DESCRIPTION
Hi @jmulet, 
This PR aims to remove Bootstrap tooltips due to some UI issues. When using Bootstrap tooltips (data-toggle="tooltip"), clicking the button displays the tooltips, but they remain sticky and don’t disappear until you click another area. Please see the gif below:

![2024-08-14_10h00_24](https://github.com/user-attachments/assets/5945d275-1c40-4fc8-8c86-b5c9b443e13b)

I believe a better approach would be to stop using Bootstrap tooltips in favor of other smaller plugins that offer more consistent behavior. Otherwise, you should use JS to blur/hide the tooltips when clicking on the buttons.

Thanks.